### PR TITLE
Revert "add sentry to httpserver"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   'typing-compat; python_version < "3.8"',
   "typing_extensions>=4.1.0",
   "uvicorn[standard]>=0.12,<1",
-  "sentry-sdk=^1.35.0"
 ]
 
 optional-dependencies = { "dev" = [

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -6,7 +6,6 @@ import socket
 import sys
 import textwrap
 import threading
-import sentry_sdk
 from enum import Enum, auto, unique
 from typing import Any, Callable, Dict, Optional, Union
 
@@ -30,25 +29,6 @@ from ..predictor import (get_input_type, get_output_type, get_predictor_ref,
 from .runner import PredictionRunner, RunnerBusyError, UnknownPredictionError
 
 log = structlog.get_logger("cog.server.http")
-
-
-sentry_dsn = os.getenv("SENTRY_DSN", None)
-traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.0"))
-profiles_sample_rate = float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.0"))
-environment = os.getenv("SENTRY_ENVIRONMENT", "production")
-if sentry_dsn is not None:
-    sentry_sdk.init(
-        dsn=sentry_dsn,
-        # Set traces_sample_rate to 1.0 to capture 100%
-        # of transactions for performance monitoring.
-        traces_sample_rate=traces_sample_rate,
-        # Set profiles_sample_rate to 1.0 to profile 100%
-        # of sampled transactions.
-        # We recommend adjusting this value in production.
-        profiles_sample_rate=profiles_sample_rate,
-        enable_tracing=True,
-        environment=environment,
-    )
 
 
 @unique


### PR DESCRIPTION
Reverts cardinalblue/cog#3

BUG
```
root@54cea4690798:/src# pip uninstall cog
Found existing installation: cog 0.8.7.dev10+g072f447
Uninstalling cog-0.8.7.dev10+g072f447:
  Would remove:
    /usr/local/lib/python3.9/site-packages/cog-0.8.7.dev10+g072f447.dist-info/*
    /usr/local/lib/python3.9/site-packages/cog/*
    /usr/local/lib/python3.9/site-packages/tests/*
Proceed (Y/n)? y
  Successfully uninstalled cog-0.8.7.dev10+g072f447
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
root@54cea4690798:/src# pip install git+https://github.com/cardinalblue/cog.git@remove_unused_features
Collecting git+https://github.com/cardinalblue/cog.git@remove_unused_features
  Cloning https://github.com/cardinalblue/cog.git (to revision remove_unused_features) to /tmp/pip-req-build-l7n5oi4n
  Running command git clone --filter=blob:none --quiet https://github.com/cardinalblue/cog.git /tmp/pip-req-build-l7n5oi4n
  Running command git checkout -b remove_unused_features --track origin/remove_unused_features
  Switched to a new branch 'remove_unused_features'
  branch 'remove_unused_features' set up to track 'origin/remove_unused_features'.
  Resolved https://github.com/cardinalblue/cog.git to commit b0a58cf4ab787b7b0c6460b2224ac14a8b90ef5d
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [44 lines of output]
      configuration error: `project.dependencies[9]` must be pep508
      DESCRIPTION:
          Project dependency specification according to PEP 508
      
      GIVEN VALUE:
          "sentry-sdk=^1.35.0"
      
      OFFENDING RULE: 'format'
      
      DEFINITION:
          {
              "$id": "#/definitions/dependency",
              "title": "Dependency",
              "type": "string",
              "format": "pep508"
          }
      Traceback (most recent call last):
        File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 1, in <module>
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 159, in setup
          dist.parse_config_files()
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 627, in parse_config_files
          pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 66, in apply_configuration
          config = read_configuration(filepath, True, ignore_option_errors, dist)
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 127, in read_configuration
          validate(subset, filepath)
        File "/tmp/pip-build-env-38wepjlj/overlay/lib/python3.9/site-packages/setuptools/config/pyprojecttoml.py", line 55, in validate
          raise ValueError(f"{error}\n{summary}") from None
      ValueError: invalid pyproject.toml config: `project.dependencies[9]`.
      configuration error: `project.dependencies[9]` must be pep508
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip is available: 23.0.1 -> 23.3.1
[notice] To update, run: pip install --upgrade pip
```