### PR TITLE
Return error if it's busy

### DIFF
--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -142,6 +142,11 @@ def create_app(
             return JSONResponse(
                 {"detail": "Server is starting"}, status_code=503
             )
+         # Cog server is designed to handle one request at a time
+        if runner.is_busy():
+            return JSONResponse(
+                {"detail": "Server is busy"}, status_code=503
+            )
         return jsonable_encoder(
             {
                 "status": health.name,


### PR DESCRIPTION
Even if we configure Knative to only accept one request at a time, we still receive few `already running a prediction` error, so we make the readiness probe to be able to check if it's busy to reduce the possibility of this issue.