### PR TITLE
fix: Update Pydantic schema to make openapi additional property false

### DIFF
--- a/python/cog/schema.py
+++ b/python/cog/schema.py
@@ -40,8 +40,15 @@ class WebhookEvent(str, Enum):
         return [cls.START, cls.OUTPUT, cls.LOGS, cls.COMPLETED]
 
 
-class PredictionBaseModel(pydantic.BaseModel, extra=pydantic.Extra.allow):
-    pass
+class PredictionBaseModel(pydantic.BaseModel):
+    if PYDANTIC_V2:
+        model_config = pydantic.ConfigDict(use_enum_values=True)  # type: ignore
+    else:
+
+        class Config:
+            # When using `choices`, the type is converted into an enum to validate
+            # But, after validation, we want to pass the actual value to predict(), not the enum object
+            use_enum_values = True
 
 
 if PYDANTIC_V2:
@@ -57,6 +64,7 @@ else:
 
 
 class PredictionRequest(PredictionBaseModel):
+    input: Dict[str, Any]
     id: Optional[str] = None
     created_at: Optional[datetime] = None
 
@@ -92,6 +100,7 @@ class NewPredictionRequest(PredictionBaseModel):
 
 
 class PredictionResponse(PredictionBaseModel):
+    input: Dict[str, Any]
     output: Any = None
 
     id: Optional[str] = None

--- a/python/cog/server/http.py
+++ b/python/cog/server/http.py
@@ -317,7 +317,7 @@ def create_app(  # pylint: disable=too-many-arguments,too-many-locals,too-many-s
         #     request.input = {}
         all_results = []
         for instance in request.instances:
-            instance_request = schema.PredictionRequest(input=instance)
+            instance_request = PredictionRequest(input=instance)
             task_kwargs = {}
             if respond_async:
                 # For now, we only ask PredictionService to handle file uploads for

--- a/python/tests/server/test_http.py
+++ b/python/tests/server/test_http.py
@@ -220,9 +220,6 @@ def test_openapi_specification(client, static_schema):
             }
         },
     }
-    if PYDANTIC_V2:
-        new_prediction_request_schema["additionalProperties"] = True
-        new_prediction_response_schema["additionalProperties"] = True
 
     assert (
         schema["components"]["schemas"]["NewPredictionRequest"]


### PR DESCRIPTION
# Description

* Removed `extra=pydantic.Extra.allow` from `PredictionBaseModel`
* Added explicit `input: Dict[str, Any]` field to request/response models
* Updated related tests
